### PR TITLE
Fix playback of uncompressed log files

### DIFF
--- a/src/common/format/file_format_timestamp_type_size_raw_message.cpp
+++ b/src/common/format/file_format_timestamp_type_size_raw_message.cpp
@@ -31,7 +31,7 @@ void FileFormatTimestampTypeSizeRawMessage::writeHeaderToStream(QDataStream& str
 bool FileFormatTimestampTypeSizeRawMessage::readHeaderFromStream(QDataStream& stream)
 {
     char name[13];
-    name[13] = '\0';
+    name[12] = '\0';
     stream.readRawData(name, sizeof(name) - 1);
 
     qint32 version;


### PR DESCRIPTION
The C-String was terminated one character behind the array, so random characters could sneak in for the last character. This showed up while opening uncompressed log files, when parsing of the header failed.