### PR TITLE
Avoid blocked local port

### DIFF
--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -57,7 +57,7 @@ void Network::connect()
 
     m_socket = new MulticastSocket(this);
     QObject::connect(m_socket, SIGNAL(readyRead()), SLOT(readData()));
-    m_socket->bind(m_port, QUdpSocket::ShareAddress  | QUdpSocket::ReuseAddressHint);
+    m_socket->bind(0, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
     m_socket->joinMulticastGroup(m_groupAddress);
 
     if (m_socket->state() != QAbstractSocket::BoundState) {

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -33,9 +33,10 @@
  * \param groupAddress Address of the multicast group to listen on
  * \param port Port to listen on
  */
-Network::Network(const QHostAddress &groupAddress, quint16 port) :
+Network::Network(const QHostAddress &groupAddress, quint16 localPort, quint16 targetPort) :
     m_groupAddress(groupAddress),
-    m_port(port),
+    m_local_port(localPort),
+    m_target_port(targetPort),
     m_socket(NULL)
 {
 }
@@ -57,7 +58,7 @@ void Network::connect()
 
     m_socket = new MulticastSocket(this);
     QObject::connect(m_socket, SIGNAL(readyRead()), SLOT(readData()));
-    m_socket->bind(0, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+    m_socket->bind(m_local_port, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
     m_socket->joinMulticastGroup(m_groupAddress);
 
     if (m_socket->state() != QAbstractSocket::BoundState) {
@@ -94,5 +95,5 @@ void Network::readData()
  */
 void Network::writeData(const QByteArray& data)
 {
-    m_socket->writeDatagram(data, m_groupAddress, m_port);
+    m_socket->writeDatagram(data, m_groupAddress, m_target_port);
 }

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -35,8 +35,8 @@
  */
 Network::Network(const QHostAddress &groupAddress, quint16 localPort, quint16 targetPort) :
     m_groupAddress(groupAddress),
-    m_local_port(localPort),
-    m_target_port(targetPort),
+    m_localPort(localPort),
+    m_targetPort(targetPort),
     m_socket(NULL)
 {
 }
@@ -58,7 +58,7 @@ void Network::connect()
 
     m_socket = new MulticastSocket(this);
     QObject::connect(m_socket, SIGNAL(readyRead()), SLOT(readData()));
-    m_socket->bind(m_local_port, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+    m_socket->bind(m_localPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
     m_socket->joinMulticastGroup(m_groupAddress);
 
     if (m_socket->state() != QAbstractSocket::BoundState) {
@@ -95,5 +95,5 @@ void Network::readData()
  */
 void Network::writeData(const QByteArray& data)
 {
-    m_socket->writeDatagram(data, m_groupAddress, m_target_port);
+    m_socket->writeDatagram(data, m_groupAddress, m_targetPort);
 }

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -19,7 +19,7 @@ class Network : public QObject
     Q_OBJECT
 
 public:
-    Network(const QHostAddress &groupAddress, quint16 port);
+    Network(const QHostAddress &groupAddress, quint16 localPort, quint16 targetPort);
     ~Network();
 
 signals:
@@ -37,7 +37,8 @@ private slots:
 
 private:
     QHostAddress m_groupAddress;
-    quint16 m_port;
+    quint16 m_local_port;
+    quint16 m_target_port;
     QUdpSocket *m_socket;
 };
 

--- a/src/common/network.h
+++ b/src/common/network.h
@@ -37,8 +37,8 @@ private slots:
 
 private:
     QHostAddress m_groupAddress;
-    quint16 m_local_port;
-    quint16 m_target_port;
+    quint16 m_localPort;
+    quint16 m_targetPort;
     QUdpSocket *m_socket;
 };
 

--- a/src/common/recorder.cpp
+++ b/src/common/recorder.cpp
@@ -49,7 +49,7 @@ bool Recorder::start(const QString& filename, bool compress, int formatVersion)
 
     // create referee socket
     Q_ASSERT(m_referee == NULL);
-    m_referee = new Network(QHostAddress("224.5.23.1"), 10003);
+    m_referee = new Network(QHostAddress("224.5.23.1"), 10003, 0);
     m_referee->moveToThread(m_networkThread);
     QObject::connect(m_networkThread, SIGNAL(started()), m_referee, SLOT(connect()));
     QObject::connect(m_networkThread, SIGNAL(finished()), m_referee, SLOT(disconnect()));
@@ -57,7 +57,7 @@ bool Recorder::start(const QString& filename, bool compress, int formatVersion)
 
     // create vision socket
     Q_ASSERT(m_vision == NULL);
-    m_vision = new Network(QHostAddress("224.5.23.2"), 10006);
+    m_vision = new Network(QHostAddress("224.5.23.2"), 10006, 0);
     m_vision->moveToThread(m_networkThread);
     QObject::connect(m_networkThread, SIGNAL(started()), m_vision, SLOT(connect()));
     QObject::connect(m_networkThread, SIGNAL(finished()), m_vision, SLOT(disconnect()));
@@ -65,7 +65,7 @@ bool Recorder::start(const QString& filename, bool compress, int formatVersion)
 
     // create legacy vision socket
     Q_ASSERT(m_legacyVision == NULL);
-    m_legacyVision = new Network(QHostAddress("224.5.23.2"), 10005);
+    m_legacyVision = new Network(QHostAddress("224.5.23.2"), 10005, 0);
     m_legacyVision->moveToThread(m_networkThread);
     QObject::connect(m_networkThread, SIGNAL(started()), m_legacyVision, SLOT(connect()));
     QObject::connect(m_networkThread, SIGNAL(finished()), m_legacyVision, SLOT(disconnect()));

--- a/src/logplayer/player.cpp
+++ b/src/logplayer/player.cpp
@@ -23,17 +23,17 @@ Player::Player() :
 {
     // create referee socket
     Q_ASSERT(m_referee == NULL);
-    m_referee = new Network(QHostAddress("224.5.23.1"), 10003);
+    m_referee = new Network(QHostAddress("224.5.23.1"), 0, 10003);
     m_referee->connect();
 
     // create vision socket
     Q_ASSERT(m_vision == NULL);
-    m_vision = new Network(QHostAddress("224.5.23.2"), 10006);
+    m_vision = new Network(QHostAddress("224.5.23.2"), 0, 10006);
     m_vision->connect();
 
     // create legacy vision socket
     Q_ASSERT(m_legacyVision == NULL);
-    m_legacyVision = new Network(QHostAddress("224.5.23.2"), 10005);
+    m_legacyVision = new Network(QHostAddress("224.5.23.2"), 0, 10005);
     m_legacyVision->connect();
 }
 


### PR DESCRIPTION
The QUdpSocket does not set the bind hints for SO_REUSEPORT correctly.
Other applications that try to bind to the same local port (which is quite common) will fail, if they are started after the log tools.
Using a random free port solves this issue.