### PR TITLE
Qt 5 support + warning fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ compiler:
 before_install:
   - sudo apt-get update -qq
   - sudo ./installDeps.sh
+  - 'if [ "$CMAKE_ARGS" = "-DUSE_QT5=True" ]; then sudo apt-get install -qq qtbase5-dev; fi'
 
 env:
   - CMAKE_ARGS=""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,43 @@
-cmake_minimum_required(VERSION 2.8.2)
 project(ssl-logtools)
+
+set(USE_QT5 FALSE CACHE BOOL "Use Qt5 instead of Qt4")
+if(USE_QT5)
+	cmake_minimum_required(VERSION 2.8.9)
+	if(POLICY CMP0020)
+	    cmake_policy(SET CMP0020 NEW) # remove if CMake >= 2.8.11 required
+	endif()
+	if(POLICY CMP0043) # compatibility with CMake 3.0.1
+	    cmake_policy(SET CMP0043 OLD)
+	endif()
+	if(POLICY CMP0071) # compatibility with CMake 3.10.0
+	    cmake_policy(SET CMP0071 OLD)
+	endif()
+else()
+	cmake_minimum_required(VERSION 2.8.2)
+endif()
 
 find_package(Threads REQUIRED)
 find_package(Protobuf REQUIRED)
-find_package(Qt4 4.6.0 COMPONENTS QtCore QtGui QtNetwork REQUIRED)
+
+if(USE_QT5)
+	set(CMAKE_INCLUDE_CURRENT_DIR ON)
+	set(CMAKE_AUTOMOC ON)
+	find_package(Qt5 COMPONENTS Core Widgets Network REQUIRED)
+	# replaced by automoc
+	macro(qt4_wrap_cpp VARNAME)
+		set(${VARNAME} "")
+	endmacro()
+	# wrap functions
+	macro(qt4_wrap_ui)
+		qt5_wrap_ui(${ARGN})
+	endmacro()
+	macro(qt4_add_resources)
+		qt5_add_resources(${ARGN})
+	endmacro()
+else()
+	find_package(Qt4 4.6.0 COMPONENTS QtCore QtGui QtNetwork REQUIRED)
+endif()
+
 find_package(Boost 1.42.0 COMPONENTS program_options REQUIRED)
 find_package(ZLIB REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8.2)
 project(ssl-logtools)
 
-find_package(Threads)
-find_package(Protobuf)
-find_package(Qt4 4.6.0)
-find_package(Boost 1.42.0 COMPONENTS program_options)
-find_package(ZLIB)
+find_package(Threads REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(Qt4 4.6.0 COMPONENTS QtCore QtGui QtNetwork REQUIRED)
+find_package(Boost 1.42.0 COMPONENTS program_options REQUIRED)
+find_package(ZLIB REQUIRED)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(QT_DONT_USE_QTGUI true)
-set(QT_USE_QTNETWORK true)
-include(${QT_USE_FILE})
-
 include_directories(${PROTOBUF_INCLUDE_DIR})
 
 set(SOURCES
@@ -30,7 +26,8 @@ set(MOC_SOURCES
 qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
 
 add_library(common ${SOURCES} ${MOC_SOURCES})
-target_link_libraries(common protobuf qt ${QT_LIBRARIES})
+target_link_libraries(common protobuf qt ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
 
 if(WIN32)
     target_link_libraries(core wsock32)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -26,8 +26,13 @@ set(MOC_SOURCES
 qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
 
 add_library(common ${SOURCES} ${MOC_SOURCES})
-target_link_libraries(common protobuf qt ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
-include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+target_link_libraries(common protobuf qt)
+if(USE_QT5)
+	target_link_libraries(common Qt5::Core Qt5::Network)
+else()
+	target_link_libraries(common ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+endif()
 
 if(WIN32)
     target_link_libraries(core wsock32)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -35,5 +35,5 @@ else()
 endif()
 
 if(WIN32)
-    target_link_libraries(core wsock32)
+    target_link_libraries(common wsock32)
 endif()

--- a/src/common/logfile.cpp
+++ b/src/common/logfile.cpp
@@ -156,6 +156,8 @@ void LogFile::saveMessage(const QByteArray& data, qint64 time, MessageType type)
     }
 
     QDataStream stream(m_io);
+    stream.setVersion(QDataStream::Qt_4_6);
+
     format->writeMessageToStream(stream, data, time, type);
 }
 
@@ -174,6 +176,7 @@ bool LogFile::readMessage(QByteArray& data, qint64& time, MessageType& type)
     }
 
     QDataStream stream(m_io);
+    stream.setVersion(QDataStream::Qt_4_6);
 
     if (stream.atEnd()) {
         return false;

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -12,6 +12,7 @@
 #include "qt/multicastsocket.h"
 #include "network.h"
 #include "timer.h"
+#include <QtGlobal>
 
 /*!
  * \class Network
@@ -58,7 +59,11 @@ void Network::connect()
 
     m_socket = new MulticastSocket(this);
     QObject::connect(m_socket, SIGNAL(readyRead()), SLOT(readData()));
-    m_socket->bind(m_localPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+#if QT_VERSION >= 0x050000
+    m_socket->bind(QHostAddress::AnyIPv4, m_localPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+#else
+    m_socket->bind(QHostAddress::Any, m_localPort, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+#endif
     m_socket->joinMulticastGroup(m_groupAddress);
 
     if (m_socket->state() != QAbstractSocket::BoundState) {

--- a/src/examples/examplereader.cpp
+++ b/src/examples/examplereader.cpp
@@ -1,5 +1,5 @@
 #include "protobuf/ssl_referee.pb.h"
-#include "protobuf/ssl_wrapper.pb.h"
+#include "protobuf/messages_robocup_ssl_wrapper.pb.h"
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/src/logconvert/CMakeLists.txt
+++ b/src/logconvert/CMakeLists.txt
@@ -5,6 +5,10 @@ set(SOURCES
 )
 
 add_executable(logconvert ${SOURCES})
-target_link_libraries(logconvert common ${Boost_LIBRARIES} ${QT_QTCORE_LIBRARY})
-include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR})
-
+target_link_libraries(logconvert common ${Boost_LIBRARIES})
+if(USE_QT5)
+	target_link_libraries(logconvert Qt5::Core)
+else()
+	target_link_libraries(logconvert ${QT_QTCORE_LIBRARY})
+	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR})
+endif()

--- a/src/logconvert/CMakeLists.txt
+++ b/src/logconvert/CMakeLists.txt
@@ -1,10 +1,10 @@
 include_directories(${Boost_INCLUDE_DIRS})
-set(QT_DONT_USE_QTGUI true)
-include(${QT_USE_FILE})
 
 set(SOURCES
     logconvert.cpp
 )
 
 add_executable(logconvert ${SOURCES})
-target_link_libraries(logconvert common ${Boost_LIBRARIES} ${QT_LIBRARIES})
+target_link_libraries(logconvert common ${Boost_LIBRARIES} ${QT_QTCORE_LIBRARY})
+include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR})
+

--- a/src/logconvert/CMakeLists.txt
+++ b/src/logconvert/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${PROTOBUF_INCLUDE_DIR})
 include_directories(${Boost_INCLUDE_DIRS})
 
 set(SOURCES

--- a/src/logplayer/CMakeLists.txt
+++ b/src/logplayer/CMakeLists.txt
@@ -19,6 +19,10 @@ qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
 qt4_wrap_ui(UIC_SOURCES ${UI_SOURCES})
 
 add_executable(logplayer ${SOURCES} ${MOC_SOURCES} ${UIC_SOURCES})
-target_link_libraries(logplayer common ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY})
-include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
-
+target_link_libraries(logplayer common)
+if(USE_QT5)
+	target_link_libraries(logplayer Qt5::Widgets Qt5::Network)
+else()
+	target_link_libraries(logplayer ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+endif()

--- a/src/logplayer/CMakeLists.txt
+++ b/src/logplayer/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${PROTOBUF_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(SOURCES

--- a/src/logplayer/CMakeLists.txt
+++ b/src/logplayer/CMakeLists.txt
@@ -1,9 +1,5 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-set(QT_USE_QTGUI true)
-set(QT_USE_QTNETWORK true)
-include(${QT_USE_FILE})
-
 set(SOURCES
     logplayer.cpp
     mainwindow.cpp
@@ -23,4 +19,6 @@ qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
 qt4_wrap_ui(UIC_SOURCES ${UI_SOURCES})
 
 add_executable(logplayer ${SOURCES} ${MOC_SOURCES} ${UIC_SOURCES})
-target_link_libraries(logplayer common ${QT_LIBRARIES})
+target_link_libraries(logplayer common ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+

--- a/src/logplayer/player.cpp
+++ b/src/logplayer/player.cpp
@@ -136,7 +136,7 @@ void Player::sendMessage(const Frame* packet)
     } else if (packet->type == MESSAGE_SSL_VISION_2014) {
         m_vision->writeData(packet->data);
     } else {
-        std::cout << "Error unsupported message type found in log file!" << endl;
+        std::cout << "Error unsupported message type found in log file!" << std::endl;
     }
 }
 

--- a/src/logrecorder/CMakeLists.txt
+++ b/src/logrecorder/CMakeLists.txt
@@ -1,11 +1,10 @@
 include_directories(${Boost_INCLUDE_DIRS})
-set(QT_DONT_USE_QTGUI true)
-set(QT_USE_QTNETWORK true)
-include(${QT_USE_FILE})
 
 set(SOURCES
     logrecorder.cpp
 )
 
 add_executable(logrecorder ${SOURCES})
-target_link_libraries(logrecorder common ${Boost_LIBRARIES} ${QT_LIBRARIES})
+target_link_libraries(logrecorder common ${Boost_LIBRARIES} ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+

--- a/src/logrecorder/CMakeLists.txt
+++ b/src/logrecorder/CMakeLists.txt
@@ -5,6 +5,10 @@ set(SOURCES
 )
 
 add_executable(logrecorder ${SOURCES})
-target_link_libraries(logrecorder common ${Boost_LIBRARIES} ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
-include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
-
+target_link_libraries(logrecorder common ${Boost_LIBRARIES})
+if(USE_QT5)
+	target_link_libraries(logrecorder Qt5::Core Qt5::Network)
+else()
+	target_link_libraries(logrecorder ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+endif()

--- a/src/protobuf/CMakeLists.txt
+++ b/src/protobuf/CMakeLists.txt
@@ -13,3 +13,4 @@ protobuf_generate_cpp(PROTO_SOURCES PROTO_HEADERS ${PROTO_FILES})
 
 add_library(protobuf ${PROTO_SOURCES} ${PROTO_HEADERS} ${PROTO_FILES})
 target_link_libraries(protobuf ${PROTOBUF_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+

--- a/src/protobuf/messages_robocup_ssl_detection.proto
+++ b/src/protobuf/messages_robocup_ssl_detection.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message SSL_DetectionBall {
   required float  confidence = 1;
   optional uint32 area       = 2;

--- a/src/protobuf/messages_robocup_ssl_geometry.proto
+++ b/src/protobuf/messages_robocup_ssl_geometry.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // A 2D float vector.
 message Vector2f {
   required float x = 1;

--- a/src/protobuf/messages_robocup_ssl_geometry_legacy.proto
+++ b/src/protobuf/messages_robocup_ssl_geometry_legacy.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "messages_robocup_ssl_geometry.proto";
 package RoboCup2014Legacy.Geometry;
 

--- a/src/protobuf/messages_robocup_ssl_wrapper.proto
+++ b/src/protobuf/messages_robocup_ssl_wrapper.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "messages_robocup_ssl_detection.proto";
 import "messages_robocup_ssl_geometry.proto";
 

--- a/src/protobuf/messages_robocup_ssl_wrapper_legacy.proto
+++ b/src/protobuf/messages_robocup_ssl_wrapper_legacy.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "messages_robocup_ssl_detection.proto";
 import "messages_robocup_ssl_geometry_legacy.proto";
 

--- a/src/protobuf/ssl_referee.proto
+++ b/src/protobuf/ssl_referee.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // Each UDP packet contains one of these messages.
 message SSL_Referee {
 	// The UNIX timestamp when the packet was sent, in microseconds.

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(QT_DONT_USE_QTGUI true)
-set(QT_USE_QTNETWORK true)
-include(${QT_USE_FILE})
-
 set(SOURCES
     multicastsocket.cpp
     multicastsocket.h
@@ -16,7 +12,8 @@ set(MOC_SOURCES
 qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
 
 add_library(qt ${SOURCES} ${MOC_SOURCES})
-target_link_libraries(qt ${QT_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(qt ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${ZLIB_LIBRARIES})
+include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
 
 if(WIN32)
     target_link_libraries(core wsock32)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -12,8 +12,13 @@ set(MOC_SOURCES
 qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
 
 add_library(qt ${SOURCES} ${MOC_SOURCES})
-target_link_libraries(qt ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${ZLIB_LIBRARIES})
-include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+target_link_libraries(qt ${ZLIB_LIBRARIES})
+if(USE_QT5)
+	target_link_libraries(qt Qt5::Core Qt5::Network)
+else()
+	target_link_libraries(qt ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
+	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+endif()
 
 if(WIN32)
     target_link_libraries(core wsock32)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -21,5 +21,5 @@ else()
 endif()
 
 if(WIN32)
-    target_link_libraries(core wsock32)
+    target_link_libraries(qt wsock32)
 endif()


### PR DESCRIPTION
The pull request adds support for building with Qt5. Modify the cmake command to `cmake -DUSE_QT5=True ..` to build with Qt5.
These changes are accompanied by several fixes for compiler, protobuf and qt warnings.

It might be worthwhile to raise the required version to CMake 3.5 and Qt 5.2. Even those library versions are old enough to be available on Ubuntu 14.04 (CMake is available as a backported package named `cmake3`). This would allow for several cleanups such as dropping qt4 support, "modern" cmake based on targets. As Qt5 also includes a commandline-options parser the dependency to boost could be removed.