### PR TITLE
I couldn't get Qt4 easily on my WSL 24.04 so I made Gemini fix it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/build
+/buildCMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,45 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
 project(ssl-logtools)
-
-set(USE_QT5 FALSE CACHE BOOL "Use Qt5 instead of Qt4")
-if(USE_QT5)
-	cmake_minimum_required(VERSION 2.8.9)
-	if(POLICY CMP0020)
-	    cmake_policy(SET CMP0020 NEW) # remove if CMake >= 2.8.11 required
-	endif()
-	if(POLICY CMP0043) # compatibility with CMake 3.0.1
-	    cmake_policy(SET CMP0043 OLD)
-	endif()
-	if(POLICY CMP0071) # compatibility with CMake 3.10.0
-	    cmake_policy(SET CMP0071 OLD)
-	endif()
-else()
-	cmake_minimum_required(VERSION 2.8.2)
-endif()
 
 find_package(Threads REQUIRED)
 find_package(Protobuf REQUIRED)
-
-if(USE_QT5)
-	set(CMAKE_INCLUDE_CURRENT_DIR ON)
-	set(CMAKE_AUTOMOC ON)
-	find_package(Qt5 COMPONENTS Core Widgets Network REQUIRED)
-	# replaced by automoc
-	macro(qt4_wrap_cpp VARNAME)
-		set(${VARNAME} "")
-	endmacro()
-	# wrap functions
-	macro(qt4_wrap_ui)
-		qt5_wrap_ui(${ARGN})
-	endmacro()
-	macro(qt4_add_resources)
-		qt5_add_resources(${ARGN})
-	endmacro()
-else()
-	find_package(Qt4 4.6.0 COMPONENTS QtCore QtGui QtNetwork REQUIRED)
-endif()
-
+find_package(Qt6 COMPONENTS Core Widgets Network REQUIRED)
 find_package(Boost 1.42.0 COMPONENTS program_options REQUIRED)
 find_package(ZLIB REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 

--- a/README.md
+++ b/README.md
@@ -20,20 +20,26 @@ Compiling:
 All programs should compile on GNU/Linux, Windows and Mac OS X.
 
 In order to build the ssl-logtools you will need:
-  * cmake-2.8.2
-  * g++-4.1
-  * qt-gui-4.6.0
-  * boost-program-options-1.42.0
-  * zlib-1.2.7
-  * protobuf-2.0.0
+  * cmake
+  * g++
+  * qt6-base-dev
+  * libboost-program-options-dev
+  * zlib1g-dev
+  * protobuf-compiler
+  * ninja-build
+
+On a Debian-based system, you can install the dependencies with the following command:
+```bash
+sudo apt-get install -y cmake g++ qt6-base-dev libboost-program-options-dev zlib1g-dev protobuf-compiler ninja-build
+```
 
 The recommended way of building a project with CMake is by doing an
 out-of-source build. This can be done like this:
 
 > mkdir build <br>
 > cd build <br>
-> cmake .. <br>
-> make <br>
+> cmake -G Ninja .. <br>
+> ninja <br>
 
 Binaries will be created in the subdirectory "bin" of the "build" folder.
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ In order to build the ssl-logtools you will need:
   * zlib1g-dev
   * protobuf-compiler
   * ninja-build
+  * libopengl-dev
+  * libglu1-mesa-dev
 
 On a Debian-based system, you can install the dependencies with the following command:
 ```bash
-sudo apt-get install -y cmake g++ qt6-base-dev libboost-program-options-dev zlib1g-dev protobuf-compiler ninja-build
+sudo apt-get install -y cmake g++ qt6-base-dev libboost-program-options-dev zlib1g-dev protobuf-compiler ninja-build libopengl-dev libglu1-mesa-dev
 ```
 
 The recommended way of building a project with CMake is by doing an

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,8 +2,10 @@ include_directories(${PROTOBUF_INCLUDE_DIR})
 
 set(SOURCES
     recorder.cpp
+    recorder.h
 
     network.cpp
+    network.h
     timer.cpp
     timer.h
 
@@ -18,21 +20,8 @@ set(SOURCES
     format/file_format_timestamp_type_size_raw_message.h
 )
 
-set(MOC_SOURCES
-    recorder.h
-    network.h
-)
-
-qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
-
-add_library(common ${SOURCES} ${MOC_SOURCES})
-target_link_libraries(common protobuf qt)
-if(USE_QT5)
-	target_link_libraries(common Qt5::Core Qt5::Network)
-else()
-	target_link_libraries(common ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
-	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
-endif()
+add_library(common ${SOURCES})
+target_link_libraries(common protobuf qt Qt6::Core Qt6::Network)
 
 if(WIN32)
     target_link_libraries(common wsock32)

--- a/src/common/format/file_format_legacy.cpp
+++ b/src/common/format/file_format_legacy.cpp
@@ -10,6 +10,8 @@
  ***************************************************************************/
 
 #include "file_format_legacy.h"
+#include <QString>
+#include <QByteArray>
 
 FileFormatLegacy::FileFormatLegacy() :
     FileFormat(0)

--- a/src/common/format/file_format_timestamp_type_size_raw_message.cpp
+++ b/src/common/format/file_format_timestamp_type_size_raw_message.cpp
@@ -10,6 +10,8 @@
  ***************************************************************************/
 
 #include "file_format_timestamp_type_size_raw_message.h"
+#include <QString>
+#include <QByteArray>
 
 FileFormatTimestampTypeSizeRawMessage::FileFormatTimestampTypeSizeRawMessage() :
     FileFormat(1)

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -13,6 +13,8 @@
 #include "network.h"
 #include "timer.h"
 #include <QtGlobal>
+#include <QVariant>
+#include <QNetworkInterface>
 
 /*!
  * \class Network

--- a/src/logplayer/CMakeLists.txt
+++ b/src/logplayer/CMakeLists.txt
@@ -5,25 +5,10 @@ set(SOURCES
     logplayer.cpp
     mainwindow.cpp
     player.cpp
-)
-
-set(MOC_SOURCES
     mainwindow.h
     player.h
-)
-
-set(UI_SOURCES
     mainwindow.ui
 )
 
-qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
-qt4_wrap_ui(UIC_SOURCES ${UI_SOURCES})
-
-add_executable(logplayer ${SOURCES} ${MOC_SOURCES} ${UIC_SOURCES})
-target_link_libraries(logplayer common)
-if(USE_QT5)
-	target_link_libraries(logplayer Qt5::Widgets Qt5::Network)
-else()
-	target_link_libraries(logplayer ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY})
-	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
-endif()
+add_executable(logplayer ${SOURCES})
+target_link_libraries(logplayer common Qt6::Widgets Qt6::Network)

--- a/src/protobuf/CMakeLists.txt
+++ b/src/protobuf/CMakeLists.txt
@@ -1,3 +1,9 @@
+find_package(Protobuf REQUIRED)
+find_program(PROTOC_EXECUTABLE protoc HINTS /usr/bin)
+if(NOT PROTOC_EXECUTABLE)
+    message(FATAL_ERROR "protoc executable not found")
+endif()
+
 include_directories(${PROTOBUF_INCLUDE_DIR})
 
 set(PROTO_FILES
@@ -9,8 +15,24 @@ set(PROTO_FILES
     messages_robocup_ssl_wrapper_legacy.proto
 )
 
-protobuf_generate_cpp(PROTO_SOURCES PROTO_HEADERS ${PROTO_FILES})
+set(PROTO_SOURCES)
+set(PROTO_HEADERS)
 
-add_library(protobuf ${PROTO_SOURCES} ${PROTO_HEADERS} ${PROTO_FILES})
+foreach(PROTO_FILE ${PROTO_FILES})
+    get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
+    set(GENERATED_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME}.pb.cc)
+    set(GENERATED_HEADER ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME}.pb.h)
+
+    add_custom_command(
+        OUTPUT ${GENERATED_SOURCE} ${GENERATED_HEADER}
+        COMMAND ${PROTOC_EXECUTABLE}
+        ARGS --cpp_out=${CMAKE_CURRENT_BINARY_DIR} -I${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_FILE}
+        DEPENDS ${PROTO_FILE}
+    )
+
+    list(APPEND PROTO_SOURCES ${GENERATED_SOURCE})
+    list(APPEND PROTO_HEADERS ${GENERATED_HEADER})
+endforeach()
+
+add_library(protobuf ${PROTO_SOURCES} ${PROTO_HEADERS})
 target_link_libraries(protobuf ${PROTOBUF_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -1,24 +1,12 @@
 set(SOURCES
     multicastsocket.cpp
     multicastsocket.h
-
     qtiocompressor.cpp
-)
-
-set(MOC_SOURCES
     qtiocompressor.h
 )
 
-qt4_wrap_cpp(MOC_SOURCES ${MOC_SOURCES})
-
-add_library(qt ${SOURCES} ${MOC_SOURCES})
-target_link_libraries(qt ${ZLIB_LIBRARIES})
-if(USE_QT5)
-	target_link_libraries(qt Qt5::Core Qt5::Network)
-else()
-	target_link_libraries(qt ${QT_QTCORE_LIBRARY} ${QT_QTNETWORK_LIBRARY})
-	include_directories(${QT_INCLUDE_DIR} ${QT_QTCORE_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
-endif()
+add_library(qt ${SOURCES})
+target_link_libraries(qt Qt6::Core Qt6::Network ${ZLIB_LIBRARIES})
 
 if(WIN32)
     target_link_libraries(qt wsock32)


### PR DESCRIPTION
This commit modernizes the build system to support Qt 6 and modern C++ compilers.

The key changes are:
- Updated CMakeLists.txt files to use modern CMake and find Qt 6.
- Added missing includes to the source code to support stricter C++ compilers.
- Updated the protobuf handling to be compatible with the new build system.
- Updated the README.md with the new build instructions.

This commit was generated by an AI assistant.